### PR TITLE
Release candidate setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "nextn",
       "version": "0.1.0",
       "dependencies": {
+        "@fontsource-variable/geist": "^5.2.6",
+        "@fontsource-variable/geist-mono": "^5.2.6",
         "@genkit-ai/googleai": "^1.8.0",
         "@genkit-ai/next": "^1.8.0",
         "@hookform/resolvers": "^4.1.3",
@@ -1496,6 +1498,24 @@
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
+    },
+    "node_modules/@fontsource-variable/geist": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/geist/-/geist-5.2.6.tgz",
+      "integrity": "sha512-Bt9pdD55Fojq4h9yFKQAzh5+Xj4tKFpwbcDzK6t5PPSH2GrjPoPqm6N8y+tK6vzwKZ9hHyaOz/tAbO9cQd9UFQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/geist-mono": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/geist-mono/-/geist-mono-5.2.6.tgz",
+      "integrity": "sha512-vw6T9JGTrYJ980bn7W8iTPhe2jVK5ifunVs7xh9dfTVArjDSkJs03JjeZrH5LKEpGABLXSlSlNU57HRm4tmFMg==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@genkit-ai/ai": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@fontsource-variable/geist": "^5.2.6",
+    "@fontsource-variable/geist-mono": "^5.2.6",
     "@genkit-ai/googleai": "^1.8.0",
     "@genkit-ai/next": "^1.8.0",
     "@hookform/resolvers": "^4.1.3",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,9 +1,14 @@
+@import '@fontsource-variable/geist/index.css';
+@import '@fontsource-variable/geist-mono/index.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 @layer base {
   :root {
+    --font-geist-sans: 'Geist Variable', sans-serif;
+    --font-geist-mono: 'Geist Mono Variable', monospace;
     --background: 40 30% 96%; /* Light Beige */
     --foreground: 40 10% 25%; /* Dark Greyish Brown */
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,21 +1,13 @@
 
 import type { Metadata, Viewport } from 'next';
-import { Geist, Geist_Mono } from 'next/font/google';
+import '@fontsource-variable/geist/index.css';
+import '@fontsource-variable/geist-mono/index.css';
 import './globals.css';
 import Header from '@/components/core/Header';
 import { Toaster } from "@/components/ui/toaster";
 import AppProviders from '@/components/core/AppProviders';
 import { translations } from '@/lib/translations'; // Import translations
 
-const geistSans = Geist({
-  variable: '--font-geist-sans',
-  subsets: ['latin'],
-});
-
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
-  subsets: ['latin'],
-});
 
 // Default metadata to German initially
 export const metadata: Metadata = {
@@ -39,7 +31,7 @@ export default function RootLayout({
     // The lang attribute will be set dynamically by SettingsContext on the client
     // The class (for theme) will also be set dynamically by SettingsContext
     <html lang="de" className="light">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body className="antialiased">
         <AppProviders>
           <div className="flex flex-col min-h-screen">
             <Header />


### PR DESCRIPTION
## Summary
- self-host Geist fonts instead of downloading from Google
- ensure fonts available via @fontsource packages
- update global styles to define font variables
- remove next/font usage

## Testing
- `npm run build`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684891e177d0832695ef7b7b27b7d0cd